### PR TITLE
Version update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennars</groupId>
     <artifactId>opennars-applications</artifactId>
-    <version>3.0.1-SNAPSHOT</version>
+    <version>3.0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.opennars</groupId>
             <artifactId>opennars</artifactId>
-            <version>3.0.1-SNAPSHOT</version>
+            <version>3.0.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.processing</groupId>


### PR DESCRIPTION
v3.0.1 snapshot was not resolvable anymore.
In the future: point to next stable release uploaded to maven central, this one will remain, while snapshot .jars seem to get deleted when never versions are available.